### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Connect Hub CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kenyawebs/studio_tests/security/code-scanning/3](https://github.com/kenyawebs/studio_tests/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the workflow, covering all jobs by placing it at the root level just below the workflow `name` and before the `on` block. The minimal permission necessary for these jobs is `contents: read`, which allows code checkout but no write actions (such as pushing changes or creating releases). This will restrict the workflow’s default GITHUB_TOKEN permissions to least privilege. If a particular job eventually needs broader permission, a job-level override could be added there.

This involves editing the file `.github/workflows/ci.yml`, and inserting these lines:

```yaml
permissions:
  contents: read
```

directly after the `name:` field and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
